### PR TITLE
`match_payload` too strict when encountering symbol-keyed hash.

### DIFF
--- a/lib/jsonapi_spec_helpers/matchers.rb
+++ b/lib/jsonapi_spec_helpers/matchers.rb
@@ -1,6 +1,14 @@
 RSpec::Matchers.define :match_payload do |attribute, expected|
-  match do |actual|
-    actual == expected
+  if expected.is_a?(Hash)
+    match do |actual|
+      expected.all? do |key, val|
+        actual.fetch(key, actual[key.to_s]) == val
+      end
+    end
+  else
+    match do |actual|
+      actual == expected
+    end
   end
 
   failure_message do |actual|

--- a/spec/assert_payload_spec.rb
+++ b/spec/assert_payload_spec.rb
@@ -205,6 +205,29 @@ describe JsonapiSpecHelpers do
             )
           end
         end
+
+        context 'when json payload contains string keys, but model attribute has symbol keys' do
+          before do
+            JsonapiSpecHelpers::Payload.register(:model_with_serialization) do
+              key(:serialized_config)
+            end
+          end
+
+          let(:serial_model) {
+            double \
+              serialized_config: { foo: 'bar' }
+          }
+
+          it 'still matches the data' do
+            json_model = {
+              'serialized_config' => { 'foo' => 'bar' }
+            }
+
+            expect {
+              assert_payload(:model_with_serialization, serial_model, json_model)
+            }.to_not raise_error
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
A strange edge case:

```
Expected JSON payload to have key 'configuration' == {:sku=>"FUEL", :point_factor=>"1"} but was {"sku"=>"FUEL", "point_factor"=>"1"}
./spec/controllers/actions_controller_spec.rb:10:in `block (3 
```

This seems to be happening because my serialization/deserialization layer uses `JSON.parse(serialized, symbolize_names: true` because I like using 1.9+ hash syntax and symbols for keys. For reasons, my API exposes this configuration data as an open value of the `configuration` property. However, when using `assert_payload` the string-keyed json is compared to the symbol-keyed json strictly, and naturally it fails.

I don't know what the best way to remedy this, but continuing my recent streak of open-source contributions, here's a PR.

I'm using a pretty naive strategy here to do some indifferent key fetching and iteration when `match_payload` is called with a data structure. A more robust way of doing this would be to probably set up a couple of `Proc`s and recurse through them down the data structure, but before I go that far I want to get some feedback on the solution that gets me around my edge case.

I think that indifferent matching of data structures is the right way to go, but hesitate on how complex nested structures should be handled. Can you do recursive matchers in RSpec?