### PR TITLE
added rspec dependency

### DIFF
--- a/jsonapi_spec_helpers.gemspec
+++ b/jsonapi_spec_helpers.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "actionpack", "~> 5.0"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_dependency "rspec", "~> 3.0"
 end

--- a/lib/jsonapi_spec_helpers/matchers.rb
+++ b/lib/jsonapi_spec_helpers/matchers.rb
@@ -1,3 +1,5 @@
+require 'rspec/matchers'
+
 RSpec::Matchers.define :match_payload do |attribute, expected|
   match do |actual|
     if expected.respond_to?(:as_json)


### PR DESCRIPTION
I had to add the dependency as I was getting errors in some context.
rspec should not only be development dependency of jsonapi_spec_helpers as it does require rspec at runtime even though in test environment only.

Exception attached:
```
heinrich@berlin:~/mck/org-api$ RAILS_ENV=test bundle exec rake neo4j:deploy[test] --trace
rake aborted!
Bundler::GemRequireError: There was an error while trying to load the gem 'jsonapi_spec_helpers'.
Gem Load Error is: uninitialized constant RSpec::Matchers
Backtrace for gem load error is:
/Users/heinrich/mck/jsonapi_spec_helpers/lib/jsonapi_spec_helpers/matchers.rb:1:in `<top (required)>'
/Users/heinrich/mck/jsonapi_spec_helpers/lib/jsonapi_spec_helpers.rb:3:in `<top (required)>'
/Users/heinrich/.rvm/gems/ruby-2.4.0/gems/bundler-1.15.2/lib/bundler/runtime.rb:82:in `require'
```