### PR TITLE
Feature: Member Name Styles

### DIFF
--- a/jsonapi_spec_helpers.gemspec
+++ b/jsonapi_spec_helpers.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_dependency "rspec", "~> 3.0"
+  spec.add_dependency "activesupport", ">= 4.1"
 end

--- a/lib/jsonapi_spec_helpers.rb
+++ b/lib/jsonapi_spec_helpers.rb
@@ -1,4 +1,6 @@
 require 'json'
+require 'active_support'
+require 'active_support/core_ext/string/inflections'
 require 'jsonapi_spec_helpers/version'
 require 'jsonapi_spec_helpers/helpers'
 require 'jsonapi_spec_helpers/payload'

--- a/lib/jsonapi_spec_helpers/payload.rb
+++ b/lib/jsonapi_spec_helpers/payload.rb
@@ -55,12 +55,24 @@ module JsonapiSpecHelpers
       @no_keys.reject! { |k| k == name }
       prc = blk
       prc = ->(record) { record.send(name) } if prc.nil?
-      @keys[name] = options.merge(proc: prc)
+      @keys[member_name_for(name, options)] = options.merge(proc: prc)
     end
 
     def timestamps!
-      @keys[:created_at] = key(:created_at, String)
-      @keys[:updated_at] = key(:updated_at, String)
+      @keys[member_name_for(:created_at)] = key(:created_at, String)
+      @keys[member_name_for(:updated_at)] = key(:updated_at, String)
+    end
+
+    def member_name_style(style = :underscore)
+      @member_name_style = style
+    end
+
+    private
+
+    def member_name_for(name, options = {})
+      transform_method = options.fetch :member_name_style, (@member_name_style || :underscore)
+      transform_method = :dasherize if transform_method == :hyphen
+      name.to_s.send transform_method
     end
   end
 end

--- a/spec/assert_payload_spec.rb
+++ b/spec/assert_payload_spec.rb
@@ -48,6 +48,116 @@ describe JsonapiSpecHelpers do
         assert_payload(:post, post_record, json_item)
       end
 
+      context 'with custom member name styles' do
+        let(:test_record) { double id: 1, first_name: 'First Name', last_name: 'Last Name' }
+
+        context 'when payload uses hyphens on all member names' do
+          before do
+            JsonapiSpecHelpers::Payload.register(:all_hyphens_object) do
+              member_name_style :hyphen
+              key(:first_name)
+              key(:last_name)
+            end
+          end
+
+          let(:json) do
+            {
+              'data' => {
+                'type' => 'test-object',
+                'id' => '1',
+                'attributes' => {
+                  'first-name' => 'First Name',
+                  'last-name' => 'Last Name'
+                }
+              }
+            }
+          end
+
+          it 'passes assertion' do
+            assert_payload(:all_hyphens_object, test_record, json_item)
+          end
+        end
+
+        context 'when payload uses hyphens on some member names' do
+          before do
+            JsonapiSpecHelpers::Payload.register(:some_hyphens_object) do
+              key :first_name
+              key :last_name, member_name_style: :hyphen
+            end
+          end
+
+          let(:json) do
+            {
+              'data' => {
+                'type' => 'test-object',
+                'id' => '1',
+                'attributes' => {
+                  'first_name' => 'First Name',
+                  'last-name' => 'Last Name'
+                }
+              }
+            }
+          end
+
+          it 'passes assertion' do
+            assert_payload(:some_hyphens_object, test_record, json_item)
+          end
+        end
+
+        context 'when payload uses spaces on all member names' do
+          before do
+            JsonapiSpecHelpers::Payload.register(:all_titleized_object) do
+              member_name_style :titleize
+              key :first_name
+              key :last_name
+            end
+          end
+
+          let(:json) do
+            {
+              'data' => {
+                'type' => 'test-object',
+                'id' => '1',
+                'attributes' => {
+                  'First Name' => 'First Name',
+                  'Last Name' => 'Last Name'
+                }
+              }
+            }
+          end
+
+          it 'passes assertion' do
+            assert_payload(:all_titleized_object, test_record, json_item)
+          end
+        end
+
+        context 'when payload uses spaces on some member names' do
+          before do
+            JsonapiSpecHelpers::Payload.register(:some_titleized_object) do
+              key :first_name
+              key :last_name, member_name_style: :titleize
+            end
+          end
+
+          let(:json) do
+            {
+              'data' => {
+                'type' => 'test-object',
+                'id' => '1',
+                'attributes' => {
+                  'first_name' => 'First Name',
+                  'Last Name' => 'Last Name'
+                }
+              }
+            }
+          end
+
+          it 'passes assertion' do
+            assert_payload(:some_titleized_object, test_record, json_item)
+          end
+        end
+      end
+
       context 'when json value matches payload value, but wrong type' do
         before do
           json['data']['attributes']['views'] = '100'


### PR DESCRIPTION
# What does this PR do?

Addresses #11 by implementing the following changes:

* Adds a key option `member_name_style`, which configures the style used for member names:
   * dasherize/hyphen (using dashes)
   * titleize/humanize (using spaces)
   * underscore (default, using underscores)
* Adds a method `member_name_style`, which configures the above-mentioned styles on all members.