### PR TITLE
Run payload procs in spec context

### DIFF
--- a/lib/jsonapi_spec_helpers.rb
+++ b/lib/jsonapi_spec_helpers.rb
@@ -34,7 +34,8 @@ module JsonapiSpecHelpers
         prc = options[:proc]
         if (expect(json).to have_payload_key(attribute, options[:allow_nil])) == true
           unless options[:allow_nil]
-            expect(json[attribute.to_s]).to match_payload(attribute, prc.call(record))
+            output = instance_exec(record, &prc)
+            expect(json[attribute.to_s]).to match_payload(attribute, output)
 
             if options[:type]
               expect(json[attribute.to_s]).to match_type(attribute, options[:type])

--- a/spec/assert_payload_spec.rb
+++ b/spec/assert_payload_spec.rb
@@ -37,15 +37,28 @@ describe JsonapiSpecHelpers do
 
     context 'when payload is valid' do
       let(:post_record) do
-        double \
+        attrs = {
           id: 1,
           title: 'post title',
           description: 'post description',
           views: 100
+        }
+        double(attrs).as_null_object
       end
+
+      let(:some_let_var) { 'foo' }
 
       it 'passes assertion' do
         assert_payload(:post, post_record, json_item)
+      end
+
+      it 'has access to spec context' do
+        post_record.title = some_let_var
+        item = json_item
+        item['title'] = some_let_var
+        assert_payload(:post, post_record, item) do
+          key(:title, String) { some_let_var }
+        end
       end
 
       context 'when json value matches payload value, but wrong type' do


### PR DESCRIPTION
This allows you to reference spec variables in your comparison:

```ruby
let(:bar) { 'hello!' }

assert_payload(:foo, record, json_item) do
  key(:something) { bar } # bar is now available
end
```