### PR TITLE
Fail loudly when casting non-Integer ids

### DIFF
--- a/lib/jsonapi_spec_helpers/helpers.rb
+++ b/lib/jsonapi_spec_helpers/helpers.rb
@@ -54,7 +54,7 @@ module JsonapiSpecHelpers
 
     def json_ids(integers = false)
       ids = json['data'].map { |d| d['id'] }
-      ids.map!(&:to_i) if integers
+      ids.map! { |id| Integer(id) } if integers
       ids
     end
 

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -150,6 +150,29 @@ describe JsonapiSpecHelpers do
         expect(json_ids(true)).to eq([1, 2])
       end
     end
+
+    context 'when ids are non-integers' do
+      let(:index_json) do
+        {
+          'data' => [
+            {
+              'type' => 'posts',
+              'id' => 'ABC123',
+              'attributes' => { }
+            },
+            {
+              'type' => 'posts',
+              'id' => 'KTHXBBQ',
+              'attributes' => { }
+            }
+          ]
+        }
+      end
+
+      it 'fails loudly when trying to cast to integers' do
+        expect{ json_ids(true) }.to raise_error ArgumentError
+      end
+    end
   end
 
   describe '#json_included_types' do


### PR DESCRIPTION
Using `#to_i` can cause confusing failure messages b/c non-integer values are cast to `0`. Now those values will fail to case, and we'll get a useful error message, where the fix is probably to NOT do the casting (e.g., use `json_ids` rather than `json_ids(true)`).