### PR TITLE
Support dasherized keys

### DIFF
--- a/lib/jsonapi_spec_helpers/matchers.rb
+++ b/lib/jsonapi_spec_helpers/matchers.rb
@@ -1,4 +1,5 @@
 require 'rspec/matchers'
+require 'jsonapi_spec_helpers/string_helpers'
 
 RSpec::Matchers.define :match_payload do |attribute, expected|
   match do |actual|
@@ -28,10 +29,11 @@ RSpec::Matchers.define :match_type do |attribute, type|
   end
 end
 
-RSpec::Matchers.define :have_payload_key do |expected, allow_nil|
+RSpec::Matchers.define :have_payload_key do |expected, allow_nil, dasherized|
   match do |json|
-    @has_key = json.has_key?(expected.to_s)
-    @has_value = !json[expected.to_s].nil?
+    expected = dasherized ? JsonapiSpecHelpers::StringHelpers.dasherize(expected) : expected.to_s
+    @has_key = json.has_key?(expected)
+    @has_value = !json[expected].nil?
 
     if allow_nil
       @has_key

--- a/lib/jsonapi_spec_helpers/string_helpers.rb
+++ b/lib/jsonapi_spec_helpers/string_helpers.rb
@@ -1,0 +1,11 @@
+module JsonapiSpecHelpers
+  class StringHelpers
+    class << self
+      def dasherize(attribute)
+        return attribute.to_s unless attribute.to_s.include?('_')
+
+        attribute.to_s.gsub('_','-')
+      end
+    end
+  end
+end

--- a/spec/assert_payload_spec.rb
+++ b/spec/assert_payload_spec.rb
@@ -61,6 +61,40 @@ describe JsonapiSpecHelpers do
         end
       end
 
+      context 'when dasherized: true' do
+        before do
+          JsonapiSpecHelpers::Payload.register(:post_with_dasherized_attribute) do
+            key(:dasherized_attribute)
+          end
+        end
+
+        let(:dasherized_value) { 'some value' }
+
+        let(:post_record) do
+          attrs = {
+            id: 1,
+            dasherized_attribute: dasherized_value
+          }
+          double(attrs).as_null_object
+        end
+
+        let(:json) do
+          {
+            'data' => {
+              'type' => 'posts',
+              'id' => '1',
+              'attributes' => {
+                'dasherized-attribute' => dasherized_value
+              }
+            }
+          }
+        end
+
+        it 'passes assertion' do
+          assert_payload(:post_with_dasherized_attribute, post_record, json_item, dasherized: true)
+        end
+      end
+
       context 'when json value matches payload value, but wrong type' do
         before do
           json['data']['attributes']['views'] = '100'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,7 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'action_dispatch'
 require 'jsonapi_spec_helpers'
 require 'pry'
+RSpec.configure do |c|
+  c.filter_run focus: true
+  c.run_all_when_everything_filtered = true
+end


### PR DESCRIPTION
Adds support for "dasherized" keys by providing a dedicated parameter in `assert_payload`. This can be easily set globally later on by providing a global configuration. For now it does the trick and can be easily added to existing implementations.